### PR TITLE
Fixed clipToBounds=false not supported on Android error

### DIFF
--- a/slides/app/slides/slides.component.ts
+++ b/slides/app/slides/slides.component.ts
@@ -123,7 +123,11 @@ export class SlidesComponent implements OnInit {
 		footerSection.height = sections;
 		footerSection.horizontalAlignment = 'center';
 
-		footerSection.clipToBounds = false;
+		if (app.ios) {
+		    footerSection.clipToBounds = false;
+		} else if (app.android) {
+			footerSection.android.getParent().setClipChildren(false);
+		}
 
 		footerSection.orientation = 'horizontal';
 


### PR DESCRIPTION
When using the plugin on Android, the following error is shown in the console:

"JS: clipToBounds with value false is not supported on Android. You can use this.android.getParent().setClipChildren(false) as an alternative"

The commit I've added in this pull request fixes this issue.